### PR TITLE
Add class collapsed to panel-title a

### DIFF
--- a/inc/bs_collapse.php
+++ b/inc/bs_collapse.php
@@ -23,7 +23,7 @@ function bs_citem( $params, $content=null ){
     $result =  '<div class="panel panel-default">';
     $result .= '    <div class="panel-heading">';
     $result .= '        <h4 class="panel-title">';
-    $result .= '<a class="accordion-toggle" data-toggle="collapse" data-parent="#' . $parent . '" href="#' . $id . '">';
+    $result .= '<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#' . $parent . '" href="#' . $id . '">';
     $result .= $title;
     $result .= '</a>';
     $result .= '        </h4>';


### PR DESCRIPTION
Need to add an extra class to show that the panel is closed on page load. This class is added after you close the opened panel already. Just need it on page load.
