### PR TITLE
added option to display an accordion as collapsed from the start

### DIFF
--- a/inc/bs_collapse.php
+++ b/inc/bs_collapse.php
@@ -17,7 +17,8 @@ function bs_citem( $params, $content=null ){
     extract( shortcode_atts( array(
         'id'=> '',
         'title'=> 'Collapse title',
-        'parent' => ''
+        'parent' => '',
+        'collapsed' => false,
          ), $params ) );
     $content = preg_replace( '/<br class="nc".\/>/', '', $content );
     $result =  '<div class="panel panel-default">';
@@ -28,7 +29,7 @@ function bs_citem( $params, $content=null ){
     $result .= '</a>';
     $result .= '        </h4>';
     $result .= '    </div>';
-    $result .= '    <div id="' . $id . '" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading_' . $id . '">';
+    $result .= '    <div id="' . $id . '" class="panel-collapse collapse '.($collapsed ? 'in' : '').'" role="tabpanel" aria-labelledby="heading_' . $id . '">';
     $result .= '        <div class="panel-body">';
     $result .= do_shortcode( $content );
     $result .= '        </div>';

--- a/inc/bs_collapse.php
+++ b/inc/bs_collapse.php
@@ -18,7 +18,7 @@ function bs_citem( $params, $content=null ){
         'id'=> '',
         'title'=> 'Collapse title',
         'parent' => '',
-        'collapsed' => false,
+        'open' => 'false',
          ), $params ) );
     $content = preg_replace( '/<br class="nc".\/>/', '', $content );
     $result =  '<div class="panel panel-default">';
@@ -29,7 +29,7 @@ function bs_citem( $params, $content=null ){
     $result .= '</a>';
     $result .= '        </h4>';
     $result .= '    </div>';
-    $result .= '    <div id="' . $id . '" class="panel-collapse collapse '.($collapsed ? 'in' : '').'" role="tabpanel" aria-labelledby="heading_' . $id . '">';
+    $result .= '    <div id="' . $id . '" class="panel-collapse collapse '.($open=='true'? 'in' : '').'" role="tabpanel" aria-labelledby="heading_' . $id . '">';
     $result .= '        <div class="panel-body">';
     $result .= do_shortcode( $content );
     $result .= '        </div>';

--- a/js/plugins/collapse.js
+++ b/js/plugins/collapse.js
@@ -12,6 +12,11 @@
                         name: 'itemnum',
                         value: '3',
                         label: 'Number of items'
+                    },{
+                        type: 'checkbox',
+                        name: 'isopen',
+                        checked: false,
+                        label: 'Start open?'
                     }],
                     onsubmit: function(e) {
                         // Insert content when the window form is submitted
@@ -21,7 +26,12 @@
                         for (i = 0; i < num; i++) {
                             var id = guid();
                             var title = 'Collapsible Group Item ' + (i + 1);
-                            shortcode += '[bs_citem title="' + title + '" id="citem_' + id + '" parent="collapse_' + uID + '"]<br class="nc"/>';
+                            shortcode += '[bs_citem';
+                            shortcode += ' title="' + title + '"';
+                            shortcode += ' id="citem_' + id + '"';
+                            shortcode += ' parent="collapse_' + uID + '"';
+                            shortcode += (e.data.isopen? ' open="true"': '');
+                            shortcode += ']<br class="nc"/>';
                             shortcode += 'Collapse content goes here....<br class="nc"/>';
                             shortcode += '[/bs_citem]<br class="nc"/>';
                         }


### PR DESCRIPTION
Hi there! Thanks for the awesome plugin! I found myself in need for an option to make an accordion item collapsed from the start, the option is called "collapsed" and can be used as 

```
[bs_citem title="Collapsible Group Item 1" id="citem_3a3a-1c71" parent="collapse_be87-d858" collapsed="true"]
Collapse content goes here....
[/bs_citem]
```

Cheers!