### PR TITLE
collapsed class added only when the panel is not opened at start

### DIFF
--- a/inc/bs_collapse.php
+++ b/inc/bs_collapse.php
@@ -24,7 +24,7 @@ function bs_citem( $params, $content=null ){
     $result =  '<div class="panel panel-default">';
     $result .= '    <div class="panel-heading" role="tab" id="heading_' . $id . '">';
     $result .= '        <h4 class="panel-title">';
-    $result .= '<a class="accordion-toggle collapsed" data-toggle="collapse" aria-controls="heading_' . $id . '" data-parent="#' . $parent . '" href="#' . $id . '">';
+    $result .= '<a class="accordion-toggle '.($open!='true'? 'collapsed' : '').'" data-toggle="collapse" aria-controls="heading_' . $id . '" data-parent="#' . $parent . '" href="#' . $id . '">';
     $result .= $title;
     $result .= '</a>';
     $result .= '        </h4>';


### PR DESCRIPTION
I have modified the bs_collapse.php file a little, so the class `collapsed` is not added always by default to the panel button, this way they class will only be present if the panel is closed.
